### PR TITLE
update encoding to adhere to rfc3986 (from MDN)

### DIFF
--- a/lib/hmac-sha1.coffee
+++ b/lib/hmac-sha1.coffee
@@ -10,7 +10,7 @@ crypto    = require('crypto')
 #
 # Returns the encoded string
 special_encode = (string) ->
-  encodeURIComponent(string).replace(/'/g,"%27").replace(/\!/g, "%21")
+  encodeURIComponent(string).replace(/[!'()]/g, escape).replace(/\*/g, "%2A")
 
 
 # Cleaning invloves:


### PR DESCRIPTION
LTI Provider signer's encode function did not match the spec. Should use rfc3986.

Regex grabbed from
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
