### PR TITLE
Handle urn:lti:instrole:ims/lis/ prefix

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -102,7 +102,8 @@ class Provider
   #
   has_role: (role) ->
     role = role.toLowerCase()
-    @body.roles && @body.roles.filter((r) -> r.toLowerCase() is role).length >= 1
+    regex = new RegExp("^urn:lti:role:ims/lis/" + role + "$")
+    @body.roles && @body.roles.filter((r) -> (r = r.toLowerCase()) and (r is role or regex.test(r))).length >= 1
 
 
 

--- a/test/Provider.coffee
+++ b/test/Provider.coffee
@@ -282,7 +282,13 @@ describe 'LTI.Provider', () ->
     it 'should have response outcome_service boolean', () =>
       @provider.outcome_service.should.equal true
 
+    it 'should account for the standardized urn prefix', () =>
+      provider = new @lti.Provider('key', 'secret')
+      provider.parse_request
+        body:
+          roles: 'urn:lti:role:ims/lis/Instructor'
 
+      provider.instructor.should.equal true
 
 
 


### PR DESCRIPTION
The roles parameter can sometimes contain the prefix `urn:lti:instrole:ims/lis/`, this code should help take that into consideration.

See the coding page [here](https://www.edu-apps.org/code.html) for more details.
