### PR TITLE
Implement error classes

### DIFF
--- a/src/errors.coffee
+++ b/src/errors.coffee
@@ -1,0 +1,5 @@
+exports.ConsumerError  = class ConsumerSecretError extends Error
+exports.StoreError     = class MissingStoreError extends Error
+exports.ParameterError = class ParameterError extends Error
+exports.SignatureError = class SignatureError extends Error
+exports.NonceError     = class NonceError extends Error

--- a/src/ims-lti.coffee
+++ b/src/ims-lti.coffee
@@ -7,6 +7,7 @@ exports = module.exports =
   # Provider and Consumer classes
   Provider: require './provider'
   Consumer: require './consumer'
+  Errors:   require './errors'
 
   Stores:
     RedisStore:   require './redis-nonce-store'


### PR DESCRIPTION
This is just a concept to make error handling a little better, I personally like the way Bluebird handles their errors. This allows you to do something like so. Without Bluebird you can simply do an instanceof check on the err passed into the callback.

``` js
var promise = require("bluebird");
var lti     = require("ims-lti");

var provider = new lti.Provider(myKey, mySecret, myStore);
var isValid  = Promise.promisify(provider.valid_request, provider);

isValid(req).then(function () {
  return commitToSession();
})
.catch(lti.errors.ParameterError, function () {
  res.redirect(302, req.post.launch_presentation_return_url);
})
.catch(lti.errors.SignatureError, function () {
  res.render("errors/configuration");
})
.catch(function () {
  res.render("errors/internal");
});

```
