### PR TITLE
Fix unit tests failing after multiple runs

### DIFF
--- a/test/shared.coffee
+++ b/test/shared.coffee
@@ -9,8 +9,8 @@ exports.shouldBehaveLikeNonce = (newStore=()->) =>
     @store = newStore()
 
   after () =>
-    if @store.client
-      @store.client.flushdb()
+    if @store.redis
+      @store.redis.flushdb()
 
 
 


### PR DESCRIPTION
The Redis client fails after multiple test runs because the underlying API changed at some point. The initial run will pass but each subsequent run will fail until the TTL expires.
