### PR TITLE
fix(not-express) avoid being locked into express. closes #23

### DIFF
--- a/src/hmac-sha1.coffee
+++ b/src/hmac-sha1.coffee
@@ -62,11 +62,22 @@ class HMAC_SHA1
 
     @sign_string sig.join('&'), consumer_secret, token
 
-  build_signature: (req, consumer_secret, token) ->
-    parsedUrl  = url.parse req.url, true
-    hitUrl     = req.protocol + '://' + req.get('host') + parsedUrl.pathname
+  build_signature: (req, body, consumer_secret, token) ->
+    hapiRawReq = req.raw and req.raw.req
+    if hapiRawReq
+      req = hapiRawReq
 
-    @build_signature_raw hitUrl, parsedUrl, req.method, req.body, consumer_secret, token
+    originalUrl = req.originalUrl or req.url
+    protocol = req.protocol
+    
+    if protocol is undefined
+      encrypted = req.connection.encrypted
+      protocol = (encrypted and 'https') or 'http'
+    
+    parsedUrl  = url.parse originalUrl, true
+    hitUrl     = protocol + '://' + req.headers.host + parsedUrl.pathname
+
+    @build_signature_raw hitUrl, parsedUrl, req.method, body, consumer_secret, token
 
   sign_string: (str, key, token) ->
     key = "#{key}&"

--- a/test/Signer.coffee
+++ b/test/Signer.coffee
@@ -10,27 +10,29 @@ describe 'Signer', () ->
 
   it 'should include query params', (done) ->
     req =
-      protocol: 'http'
       url: '/developers/LTI/test/v1p1/tool.php?foo=123&foo=bar'
       method: 'POST'
-      body:
-        resource_link_id: 'rsc1',
-        oauth_callback: 'about:blank',
-        lis_outcome_service_url: 'http://www.imsglobal.org/developers/LTI/test/v1p1/common/tool_consumer_outcome.php?b64=MTIzNDU6OjpzZWNyZXQ=',
-        lis_result_sourcedid: 'feb-123-456-2929::28883',
-        launch_presentation_return_url: 'http://www.imsglobal.org/developers/LTI/test/v1p1/lms_return.php',
-        lti_version: 'LTI-1p0',
-        lti_message_type: 'basic-lti-launch-request',
-        oauth_version: '1.0',
-        oauth_nonce: '7ee33f6dc94117e792ff529898ce3953',
-        oauth_timestamp: '1397708483',
-        oauth_consumer_key: '12345',
-        oauth_signature_method: 'HMAC-SHA1',
-        oauth_signature: 'dHORwwJqwh5hQQAlvaA9csSIOhc='
-      get: () -> 'www.imsglobal.org'
+      connection:
+        encrypted: undefined
+      headers:
+        host: 'www.imsglobal.org'
+    body =
+      resource_link_id: 'rsc1',
+      oauth_callback: 'about:blank',
+      lis_outcome_service_url: 'http://www.imsglobal.org/developers/LTI/test/v1p1/common/tool_consumer_outcome.php?b64=MTIzNDU6OjpzZWNyZXQ=',
+      lis_result_sourcedid: 'feb-123-456-2929::28883',
+      launch_presentation_return_url: 'http://www.imsglobal.org/developers/LTI/test/v1p1/lms_return.php',
+      lti_version: 'LTI-1p0',
+      lti_message_type: 'basic-lti-launch-request',
+      oauth_version: '1.0',
+      oauth_nonce: '7ee33f6dc94117e792ff529898ce3953',
+      oauth_timestamp: '1397708483',
+      oauth_consumer_key: '12345',
+      oauth_signature_method: 'HMAC-SHA1',
+      oauth_signature: 'dHORwwJqwh5hQQAlvaA9csSIOhc='
 
-    signature = signer.build_signature req, 'secret'
-    signature.should.equal req.body.oauth_signature
+    signature = signer.build_signature req, body, 'secret'
+    signature.should.equal body.oauth_signature
 
     done()
 


### PR DESCRIPTION
accept body as second parameter to valid_request and parse_request
avoid express-specific features such as req#get and req.protocol
add hapi-specific check to get url and protocol
- [x] Unit tests for new functionality / cases
