### PR TITLE
Update ims-lti to include HMacSha1.js

### DIFF
--- a/src/ims-lti.coffee
+++ b/src/ims-lti.coffee
@@ -9,6 +9,7 @@ exports = module.exports =
   Consumer:        require './consumer'
   OutcomeService:  require './outcome-service'
   Errors:          require './errors'
+  HMacSha1:        require './hmac-sha1'
 
   Stores:
     RedisStore:   require './redis-nonce-store'


### PR DESCRIPTION
All other libraries' files are accessible through ims-lti except hmac-sha1.js.

Including HMacSha1 so that it can be accessible through ims-lti instance.
