### PR TITLE
Query should be parsed into an object so that it is handled properly whe...

### DIFF
--- a/src/extensions/outcomes.coffee
+++ b/src/extensions/outcomes.coffee
@@ -91,7 +91,7 @@ class OutcomeService
 
     # Break apart the service url into the url fragments for use by OAuth signing, additionally prepare the OAuth
     # specific url that used exclusively in the signing process.
-    parts = @service_url_parts = url.parse @service_url
+    parts = @service_url_parts = url.parse @service_url, true
     @service_url_oauth = parts.protocol + '//' + parts.host + parts.pathname
 
 


### PR DESCRIPTION
...n building the signature.

Testing against http://www.imsglobal.org/developers/LTI/test/v1p1/lms.php, the `lis_outcome_service_url` value is `http://www.imsglobal.org/developers/LTI/test/v1p1/common/tool_consumer_outcome.php?b64=MTIzNDU6OjpzZWNyZXQ=`. The query portion was being discarded because it was not being parsed. That is it was a string `b64=MTIzNDU6OjpzZWNyZXQ=`, but should have been an object: `{b64:  'MTIzNDU6OjpzZWNyZXQ='}`
