### PR TITLE
Ensure that signature validation works behind SSL and reverse proxy

### DIFF
--- a/src/hmac-sha1.coffee
+++ b/src/hmac-sha1.coffee
@@ -58,7 +58,7 @@ class HMAC_SHA1
       req = hapiRawReq
 
     originalUrl = req.originalUrl or req.url
-    protocol = req.protocol
+    protocol = req.headers['x-forwarded-proto'] or req.protocol
 
     # Since canvas includes query parameters in the body we can omit the query string
     if body.tool_consumer_info_product_family_code == 'canvas'


### PR DESCRIPTION
When running Apache as a reverse proxy for a Node.js app using SSL, signature validation fails because of a protocol mismatch. As Apache is proxying to Node.js, the protocol on the request object will be `http` instead of `https`, causing signature validation to fail as the original URL contains `https`. Therefore, we check if the `x-forwarded-proto` header is present on the request and use that if it is. `'x-forwarded-proto` is the standard header for specifying the forwarded protocol (https://tools.ietf.org/html/rfc7239 --> `5.4. Forwarded Proto`)