### PR TITLE
Outcome service bug fix and other changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# -*- mode: ini-generic -*-
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/src/extensions/outcomes.coffee
+++ b/src/extensions/outcomes.coffee
@@ -9,6 +9,7 @@ xml2js       = require 'xml2js'
 xml_builder  = require 'xmlbuilder'
 
 errors       = require '../errors'
+HMAC_SHA1    = require '../hmac-sha1'
 utils        = require '../utils'
 
 

--- a/src/extensions/outcomes.coffee
+++ b/src/extensions/outcomes.coffee
@@ -88,6 +88,7 @@ class OutcomeService
     @source_did = options.source_did
     @result_data_types = options.result_data_types or []
     @signer = options.signer or (new HMAC_SHA1())
+    @cert_authority = options.cert_authority or null
     @language = options.language or 'en'
 
     # Break apart the service url into the url fragments for use by OAuth signing, additionally prepare the OAuth
@@ -157,10 +158,14 @@ class OutcomeService
 
     options =
       hostname:  @service_url_parts.hostname
-      agent:     if is_ssl then https.globalAgent else http.globalAgent
       path:      @service_url_parts.path
       method:    'POST'
       headers:   @_build_headers xml
+
+    if @cert_authority and is_ssl
+      options.ca = @cert_authority
+    else
+      options.agent = if is_ssl then https.globalAgent else http.globalAgent
 
     if @service_url_parts.port
       options.port = @service_url_parts.port

--- a/src/extensions/outcomes.coffee
+++ b/src/extensions/outcomes.coffee
@@ -165,7 +165,7 @@ class OutcomeService
       options.port = @service_url_parts.port
 
     # Make the request to the TC, verifying that the status code is valid and fetching the entire response body.
-    req = http.request options, (res) =>
+    req = (if is_ssl then https else http).request options, (res) =>
       res.setEncoding 'utf8'
       res.on 'data', (chunk) => body += chunk
       res.on 'end', () =>


### PR DESCRIPTION
Each commit is a separate item. Three are related to outcome service. The last is to ensure that editors obey the 2 space indentation adopted in the project.

I'm using `ims-lti` outcome service to post grades to a server that uses a self-signed certificate. The `ca` option on `https.request` makes it possible to do this.

Also, I'm posting the grades long after the launch request. Currently I'm storing parts of the original request, so that I can call `provider.parse_request` to in turn create the outcome service. I'd like to refactor the outcome service constructor to make it easier to create directly.

Last, a small bug fix. `https.request` should be used for ssl