### PR TITLE
Adding ContentItemSelectionRequest support to Provider

### DIFF
--- a/src/provider.coffee
+++ b/src/provider.coffee
@@ -35,15 +35,15 @@ class Provider
     if not callback
       callback = body
       body = undefined
-    
+
     body = body or req.body or req.payload
     callback = callback or () ->
-    
+
     @parse_request(req, body)
-    
+
     if not @_valid_parameters(body)
       return callback(new errors.ParameterError('Invalid LTI parameters'), false)
-    
+
     @_valid_oauth req, body, callback
 
 
@@ -53,8 +53,10 @@ class Provider
   _valid_parameters: (body) ->
     if not body
       return false
-    
-    correct_message_type = body.lti_message_type is 'basic-lti-launch-request'
+
+    # This could possibly be a configurable parameter of Provider.
+    supported_message_types = ['basic-lti-launch-request', 'ContentItemSelectionRequest']
+    correct_message_type = body.lti_message_type in supported_message_types
     correct_version      = require('./ims-lti').supported_versions.indexOf(body.lti_version) isnt -1
     has_resource_link_id = body.resource_link_id?
     correct_message_type and correct_version and has_resource_link_id
@@ -80,7 +82,7 @@ class Provider
   # Does not return anything
   parse_request: (req, body) =>
     body = body or req.body or req.payload
-    
+
     for key, val of body
       continue if key.match(/^oauth_/)
       @body[key] = val

--- a/test/Provider.coffee
+++ b/test/Provider.coffee
@@ -77,6 +77,7 @@ describe 'LTI.Provider', () ->
         valid.should.equal false
         done()
 
+
     it 'should return false if incorrect LTI version', (done) =>
       req_wrong_version =
         url: '/'
@@ -145,6 +146,32 @@ describe 'LTI.Provider', () ->
           host: 'localhost'
         body:
           lti_message_type: 'basic-lti-launch-request'
+          lti_version: 'LTI-1p0'
+          resource_link_id: 'http://link-to-resource.com/resource'
+          oauth_customer_key: 'key'
+          oauth_signature_method: 'HMAC-SHA1'
+          oauth_timestamp: Math.round(Date.now()/1000)
+          oauth_nonce: Date.now()+Math.random()*100
+
+      #sign the fake request
+      signature = @provider.signer.build_signature(req, req.body, 'secret')
+      req.body.oauth_signature = signature
+
+      @provider.valid_request req, (err, valid) ->
+        should.not.exist err
+        valid.should.equal true
+        done()
+
+    it 'should return true if lti_message_type is ContentItemSelectionRequest', (done) =>
+      req =
+        url: '/test'
+        method: 'POST'
+        connection:
+          encrypted: undefined
+        headers:
+          host: 'localhost'
+        body:
+          lti_message_type: 'ContentItemSelectionRequest'
           lti_version: 'LTI-1p0'
           resource_link_id: 'http://link-to-resource.com/resource'
           oauth_customer_key: 'key'
@@ -419,4 +446,3 @@ describe 'LTI.Provider', () ->
       provider.student.should.equal false
       provider.admin.should.equal false
       provider.alumni.should.equal false
-


### PR DESCRIPTION
Hiya,

IMS has recently released the [Content-Item Message extension](https://www.imsglobal.org/learning-tools-interoperability-implementing-content-item-message) for lti.

At a minimum, a Provider needs to be able to verify requests that have an `lti_message_type` of `ContentItemSelectionRequest`

This PR adds support for these types of requests and a test that validates that functionality.