### PR TITLE
Schoology only signs the pathname of the URI (just like Canvas)

### DIFF
--- a/src/hmac-sha1.coffee
+++ b/src/hmac-sha1.coffee
@@ -61,7 +61,7 @@ class HMAC_SHA1
     protocol = req.protocol
 
     # Since canvas includes query parameters in the body we can omit the query string
-    if body.tool_consumer_info_product_family_code == 'canvas'
+    if body.tool_consumer_info_product_family_code == 'canvas' or body.tool_consumer_info_product_family_code == 'schoology'
       originalUrl = url.parse(originalUrl).pathname
 
     if protocol is undefined


### PR DESCRIPTION
Schoology only uses the pathname of the URI just like Canvas does. Canvas is already special-cased w/ the HMAC-SHA1 module so special-case Schoology as well.