### PR TITLE
Content item message support

### DIFF
--- a/src/provider.coffee
+++ b/src/provider.coffee
@@ -55,12 +55,17 @@ class Provider
       return false
 
     # This could possibly be a configurable parameter of Provider.
-    supported_message_types = ['basic-lti-launch-request', 'ContentItemSelectionRequest']
-    correct_message_type = body.lti_message_type in supported_message_types
     correct_version      = require('./ims-lti').supported_versions.indexOf(body.lti_version) isnt -1
     has_resource_link_id = body.resource_link_id?
-    correct_message_type and correct_version and has_resource_link_id
-
+    omits_content_item_params = 
+      not body.resource_link_id? and
+      not body.resource_link_title? and 
+      not body.resource_link_description? and 
+      not body.launch_presentation_return_url? and
+      not body.lis_result_sourcedid?
+    correct_version and
+      ( body.lti_message_type is 'basic-lti-launch-request' and has_resource_link_id ) or
+      ( body.lti_message_type is 'ContentItemSelectionRequest' and omits_content_item_params )
 
   # Helper to validate the OAuth information in the request
   #

--- a/src/provider.coffee
+++ b/src/provider.coffee
@@ -35,15 +35,15 @@ class Provider
     if not callback
       callback = body
       body = undefined
-    
+
     body = body or req.body or req.payload
     callback = callback or () ->
-    
+
     @parse_request(req, body)
-    
+
     if not @_valid_parameters(body)
       return callback(new errors.ParameterError('Invalid LTI parameters'), false)
-    
+
     @_valid_oauth req, body, callback
 
 
@@ -53,8 +53,10 @@ class Provider
   _valid_parameters: (body) ->
     if not body
       return false
-    
-    correct_message_type = body.lti_message_type is 'basic-lti-launch-request'
+
+    # This could possibly be a configurable parameter of Provider.
+    supported_message_types = ['basic-lti-launch-request', 'ContentItemSelectionRequest']
+    correct_message_type = body.lti_message_type in supported_message_types
     correct_version      = require('./ims-lti').supported_versions.indexOf(body.lti_version) isnt -1
     has_resource_link_id = body.resource_link_id?
     correct_message_type and correct_version and has_resource_link_id
@@ -80,7 +82,7 @@ class Provider
   # Does not return anything
   parse_request: (req, body) =>
     body = body or req.body or req.payload
-    
+
     for key, val of body
       continue if key.match(/^oauth_/)
       @body[key] = val

--- a/src/provider.coffee
+++ b/src/provider.coffee
@@ -54,7 +54,6 @@ class Provider
     if not body
       return false
 
-    # This could possibly be a configurable parameter of Provider.
     correct_version      = require('./ims-lti').supported_versions.indexOf(body.lti_version) isnt -1
     has_resource_link_id = body.resource_link_id?
     omits_content_item_params = 

--- a/test/Provider.coffee
+++ b/test/Provider.coffee
@@ -77,6 +77,7 @@ describe 'LTI.Provider', () ->
         valid.should.equal false
         done()
 
+
     it 'should return false if incorrect LTI version', (done) =>
       req_wrong_version =
         url: '/'
@@ -145,6 +146,32 @@ describe 'LTI.Provider', () ->
           host: 'localhost'
         body:
           lti_message_type: 'basic-lti-launch-request'
+          lti_version: 'LTI-1p0'
+          resource_link_id: 'http://link-to-resource.com/resource'
+          oauth_customer_key: 'key'
+          oauth_signature_method: 'HMAC-SHA1'
+          oauth_timestamp: Math.round(Date.now()/1000)
+          oauth_nonce: Date.now()+Math.random()*100
+
+      #sign the fake request
+      signature = @provider.signer.build_signature(req, req.body, 'secret')
+      req.body.oauth_signature = signature
+
+      @provider.valid_request req, (err, valid) ->
+        should.not.exist err
+        valid.should.equal true
+        done()
+
+    it 'should return true if lti_message_type is ContentItemSelectionRequest', (done) =>
+      req =
+        url: '/test'
+        method: 'POST'
+        connection:
+          encrypted: undefined
+        headers:
+          host: 'localhost'
+        body:
+          lti_message_type: 'ContentItemSelectionRequest'
           lti_version: 'LTI-1p0'
           resource_link_id: 'http://link-to-resource.com/resource'
           oauth_customer_key: 'key'
@@ -419,4 +446,3 @@ describe 'LTI.Provider', () ->
       provider.student.should.equal false
       provider.admin.should.equal false
       provider.alumni.should.equal false
-

--- a/test/Provider.coffee
+++ b/test/Provider.coffee
@@ -173,7 +173,6 @@ describe 'LTI.Provider', () ->
         body:
           lti_message_type: 'ContentItemSelectionRequest'
           lti_version: 'LTI-1p0'
-          resource_link_id: 'http://link-to-resource.com/resource'
           oauth_customer_key: 'key'
           oauth_signature_method: 'HMAC-SHA1'
           oauth_timestamp: Math.round(Date.now()/1000)
@@ -186,6 +185,32 @@ describe 'LTI.Provider', () ->
       @provider.valid_request req, (err, valid) ->
         should.not.exist err
         valid.should.equal true
+        done()
+
+    it 'should return false if lti_message_type is ContentItemSelectionRequest and there is a resource_link_id', (done) =>
+      req =
+        url: '/test'
+        method: 'POST'
+        connection:
+          encrypted: undefined
+        headers:
+          host: 'localhost'
+        body:
+          lti_message_type: 'ContentItemSelectionRequest'
+          lti_version: 'LTI-1p0'
+          resource_link_id: 'http://link-to-resource.com/resource'
+          oauth_customer_key: 'key'
+          oauth_signature_method: 'HMAC-SHA1'
+          oauth_timestamp: Math.round(Date.now()/1000)
+          oauth_nonce: Date.now()+Math.random()*100
+
+      #sign the fake request
+      signature = @provider.signer.build_signature(req, req.body, 'secret')
+      req.body.oauth_signature = signature
+
+      @provider.valid_request req, (err, valid) ->
+        should.exist err
+        valid.should.equal false
         done()
 
     it 'should special case and deduplicate Canvas requests', (done) =>

--- a/test/Provider.coffee
+++ b/test/Provider.coffee
@@ -161,7 +161,7 @@ describe 'LTI.Provider', () ->
         should.not.exist err
         valid.should.equal true
         done()
-
+    
     it 'should return true if lti_message_type is ContentItemSelectionRequest', (done) =>
       req =
         url: '/test'
@@ -187,31 +187,33 @@ describe 'LTI.Provider', () ->
         valid.should.equal true
         done()
 
-    it 'should return false if lti_message_type is ContentItemSelectionRequest and there is a resource_link_id', (done) =>
-      req =
-        url: '/test'
-        method: 'POST'
-        connection:
-          encrypted: undefined
-        headers:
-          host: 'localhost'
-        body:
-          lti_message_type: 'ContentItemSelectionRequest'
-          lti_version: 'LTI-1p0'
-          resource_link_id: 'http://link-to-resource.com/resource'
-          oauth_customer_key: 'key'
-          oauth_signature_method: 'HMAC-SHA1'
-          oauth_timestamp: Math.round(Date.now()/1000)
-          oauth_nonce: Date.now()+Math.random()*100
+    it "should return false if lti_message_type is ContentItemSelectionRequest and there are invalid fields", (done) =>
+      invalidFields = [ 'resource_link_id', 'resource_link_title','resource_link_description','launch_presentation_return_url', 'lis_result_sourcedid' ]
+      for invalidField in invalidFields
+        req =
+          url: '/test'
+          method: 'POST'
+          connection:
+            encrypted: undefined
+          headers:
+            host: 'localhost'
+          body:
+            lti_message_type: 'ContentItemSelectionRequest'
+            lti_version: 'LTI-1p0'
+            oauth_customer_key: 'key'
+            oauth_signature_method: 'HMAC-SHA1'
+            oauth_timestamp: Math.round(Date.now()/1000)
+            oauth_nonce: Date.now()+Math.random()*100
+        req.body[invalidField] = "Invalid Field"
 
-      #sign the fake request
-      signature = @provider.signer.build_signature(req, req.body, 'secret')
-      req.body.oauth_signature = signature
+        #sign the fake request
+        signature = @provider.signer.build_signature(req, req.body, 'secret')
+        req.body.oauth_signature = signature
 
-      @provider.valid_request req, (err, valid) ->
-        should.exist err
-        valid.should.equal false
-        done()
+        @provider.valid_request req, (err, valid) ->
+          should.exist err
+          valid.should.equal false
+      done()
 
     it 'should special case and deduplicate Canvas requests', (done) =>
       req =


### PR DESCRIPTION
Piggybacking off of https://github.com/omsmith/ims-lti/pull/56 and making a slight change where resource_link_id, resource_link_title, resource_link_description, launch_presentation_return_url, lis_result_sourcedid should not be included in the launch as per https://www.imsglobal.org/specs/lticiv1p0/specification-3 section 3.3.1 at the bottom. 