### PR TITLE
alpha support for x-forwarded-proto

### DIFF
--- a/src/hmac-sha1.coffee
+++ b/src/hmac-sha1.coffee
@@ -68,6 +68,10 @@ class HMAC_SHA1
       encrypted = req.connection.encrypted
       protocol = (encrypted and 'https') or 'http'
     
+    # alpha support for x-forwarded-proto
+    if req.get('x-forwarded-proto') == 'https' 
+      protocol = 'https'
+      
     parsedUrl  = url.parse originalUrl, true
     hitUrl     = protocol + '://' + req.headers.host + parsedUrl.pathname
 


### PR DESCRIPTION
I haven't check yet https://www.npmjs.com/package/@dinoboff/ims-lti but it seem thats the ideal way to go. Another alternative, very naive is to check in any case whether the 'x-forwarded-proto' headers is set to HTTPS, an in this case asume that even if the actual protocol for the request is HTTP we should use HTTPS for checking the signature.